### PR TITLE
Fix up import of version info from nipype/info.py

### DIFF
--- a/nipype/__init__.py
+++ b/nipype/__init__.py
@@ -17,6 +17,15 @@ from distutils.version import LooseVersion
 
 from .fixes.numpy.testing import nosetester
 
+# Use duecredit (duecredit.org) to provide a citation to relevant work to
+# be cited. This does nothing, unless the user has duecredit installed,
+# And calls this with duecredit (as in `python -m duecredit script.py`):
+from .due import due, Doi
+due.cite(Doi("10.3389/fninf.2011.00013"),
+         description="A flexible, lightweight and extensible neuroimaging data"
+                     " processing framework in Python",
+         tags=["nipype"],)
+
 try:
     import faulthandler
     faulthandler.enable()

--- a/nipype/info.py
+++ b/nipype/info.py
@@ -2,7 +2,6 @@
 settings in setup.py, the nipy top-level docstring, and for building the
 docs.  In setup.py in particular, we exec this file, so it cannot import nipy
 """
-from .due import due, Doi
 
 # nipy version information.  An empty _version_extra corresponds to a
 # full release.  '.dev' as a _version_extra string means this is a development
@@ -101,14 +100,6 @@ systems.
 * make your research easily reproducible
 * share your processing workflows with the community
 """
-
-# Use duecredit (duecredit.org) to provide a citation to relevant work to
-# be cited. This does nothing, unless the user has duecredit installed,
-# And calls this with duecredit (as in `python -m duecredit script.py`):
-due.cite(Doi("10.3389/fninf.2011.00013"),
-         description="A flexible, lightweight and extensible neuroimaging data"
-                     " processing framework in Python",
-         tags=["nipype"],)
 
 # versions
 NIBABEL_MIN_VERSION = '2.0.1'

--- a/setup.py
+++ b/setup.py
@@ -248,7 +248,7 @@ cmdclass = {'build_py': get_comrec_build('nipype')}
 
 # Get version and release info, which is all stored in nipype/info.py
 ver_file = os.path.join('nipype', 'info.py')
-exec(open(ver_file).read())
+exec(open(ver_file).read(), locals())
 
 # Prepare setuptools args
 if 'setuptools' in sys.modules:


### PR DESCRIPTION
for exec to work seems to need env to be provided
and that precludes relative imports in info.py thus moved duecredit imports into `__init__.py`
